### PR TITLE
feat: additional info form

### DIFF
--- a/emoji-map/Services/NetworkService.swift
+++ b/emoji-map/Services/NetworkService.swift
@@ -99,6 +99,7 @@ enum APIEndpoint {
     case user
     case favorite
     case rating
+    case userVerify
     
     var path: String {
         switch self {
@@ -114,6 +115,8 @@ enum APIEndpoint {
             return "api/places/favorite"
         case .rating:
             return "api/places/rating"
+        case .userVerify:
+            return "api/user/verify"
         }
     }
 }

--- a/emoji-map/ViewModels/HomeViewModel.swift
+++ b/emoji-map/ViewModels/HomeViewModel.swift
@@ -370,8 +370,8 @@ class HomeViewModel: ObservableObject {
         }
     }
     
-    /// Handle sign-in with Apple credentials
-    /// This method moves the sign-in logic from the SettingsSheet to the ViewModel
+    /// Sign in with Apple using the provided identity token
+    @MainActor
     func signInWithApple(idToken: String) async throws {
         logger.notice("Attempting to authenticate with Clerk using Apple ID token")
         do {
@@ -390,7 +390,7 @@ class HomeViewModel: ObservableObject {
     }
     
     /// Generate a secure random nonce for Apple Sign In
-    /// This method is moved from SettingsSheet to make it reusable and keep auth logic in ViewModel
+    /// This method is used for Apple Sign In authentication
     func generateRandomNonce(length: Int = 32) -> String {
         precondition(length > 0)
         let charset: [Character] =
@@ -425,7 +425,7 @@ class HomeViewModel: ObservableObject {
     }
     
     /// Hash a string using SHA256
-    /// This method is moved from SettingsSheet to make it reusable and keep auth logic in ViewModel
+    /// This method is used for Apple Sign In authentication
     func sha256(_ input: String) -> String {
         let inputData = Data(input.utf8)
         let hashedData = SHA256.hash(data: inputData)
@@ -434,6 +434,54 @@ class HomeViewModel: ObservableObject {
         }.joined()
         
         return hashString
+    }
+    
+    /// Verify user information for users who signed in with Apple private relay
+    @MainActor
+    func verifyUserInfo(email: String, firstName: String?, lastName: String?, token: String) async throws {
+        logger.notice("Verifying user info for email \(email)")
+        
+        // Create the request body
+        struct VerifyUserInfoRequest: Encodable {
+            let email: String
+            let firstName: String?
+            let lastName: String?
+        }
+        
+        let requestBody = VerifyUserInfoRequest(
+            email: email,
+            firstName: firstName,
+            lastName: lastName
+        )
+        
+        // Get network service from ServiceContainer
+        let networkService = ServiceContainer.shared.networkService
+        
+        do {
+            // Send a POST request to /api/user/verify
+            // Update the response structure to match what the server actually returns
+            struct VerifyUserResponse: Decodable {
+                let message: String
+                
+                // Consider any response with a message as successful
+                var success: Bool {
+                    return true
+                }
+            }
+            
+            let response: VerifyUserResponse = try await networkService.post(
+                endpoint: .userVerify,
+                body: requestBody,
+                queryItems: nil,
+                authToken: token
+            )
+            
+            logger.notice("User info verified successfully: \(response.message)")
+            
+        } catch {
+            logger.error("Error verifying user info: \(error.localizedDescription)")
+            throw error
+        }
     }
     
     /// Setup location manager and handle location updates


### PR DESCRIPTION
#### Description:
- if sign in with apple flow leads to not sharing credentials, present form that asks for email / first / last name
- post that to `/api/user/verify`
- have clerk update their email and optional name fields

#### TODO:
- make it pretty
- additionally, we may want to consider always showing it, not making it conditional to `@privaterelay.apple.com`, so we can get their name which we never get on sign in with apple flow

#### Attachment(s):

#### Note(s):
