### PR TITLE
feat: sign out on reset all data

### DIFF
--- a/emoji-map/Services/ServiceContainer.swift
+++ b/emoji-map/Services/ServiceContainer.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import os.log
+import Clerk
 
 @MainActor
 class ServiceContainer {
@@ -60,6 +61,14 @@ class ServiceContainer {
         
         // Clear places cache
         placesService.clearCache()
+        
+        // Reset home view model state
+        homeViewModel.resetAllState()
+        
+        // Sign out of Clerk
+        Task {
+            try? await Clerk.shared.signOut()
+        }
         
         logger.notice("All services reset")
     }

--- a/emoji-map/ViewModels/HomeViewModel.swift
+++ b/emoji-map/ViewModels/HomeViewModel.swift
@@ -269,6 +269,59 @@ class HomeViewModel: ObservableObject {
     
     // MARK: - Public Methods
     
+    /// Reset user data and admin state when logging out
+    func resetUserState() {
+        currentUser = nil
+        isAdmin = false
+        isLoadingUser = false
+    }
+    
+    /// Reset all view model state to initial values
+    func resetAllState() {
+        // Reset user state
+        resetUserState()
+        
+        // Reset UI state
+        allPlacesById.removeAll()
+        networkFilteredPlaceIds.removeAll()
+        filteredPlaces.removeAll()
+        isLoading = false
+        errorMessage = nil
+        isFilterSheetPresented = false
+        isSettingsSheetPresented = false
+        selectedPlace = nil
+        isPlaceDetailSheetPresented = false
+        
+        // Reset category selection state
+        selectedCategoryKeys.removeAll()
+        isAllCategoriesMode = true
+        showFavoritesOnly = false
+        isCategoryGridViewVisible = false
+        
+        // Reset pending category selections
+        pendingCategoryKeys.removeAll()
+        isPendingAllCategoriesMode = true
+        
+        // Reset filter state
+        selectedPriceLevels.removeAll()
+        minimumRating = 0
+        useLocalRatings = false
+        showOpenNowOnly = false
+        
+        // Reset category mapping
+        categoryPlaceIds.removeAll()
+        
+        // Reset map state
+        visibleRegion = nil
+        lastFetchedRegion = nil
+        isSuperZoomedIn = false
+        currentViewportRadius = 5000 // Default radius
+        
+        // Cancel any pending tasks
+        regionChangeDebounceTask?.cancel()
+        fetchTask?.cancel()
+    }
+    
     /// Fetch user data from the API
     func fetchUserData(networkService: NetworkServiceProtocol? = nil, clerkService: ClerkService? = nil) async {
         logger.notice("Checking for authenticated user")

--- a/emoji-map/Views/Settings/SettingsSheet.swift
+++ b/emoji-map/Views/Settings/SettingsSheet.swift
@@ -203,8 +203,8 @@ struct SettingsSheet: View {
                         // Log Out Button
                         Button(action: {
                             Task {
+                                viewModel.resetUserState()
                                 try? await clerk.signOut()
-                                logger.notice("User signed out")
                             }
                         }) {
                             HStack {
@@ -383,11 +383,13 @@ struct SettingsSheet: View {
             Button("Reset", role: .destructive) {
                 // Reset all settings
                 ServiceContainer.shared.resetAllServices()
+                // Dismiss the settings sheet
+                viewModel.isSettingsSheetPresented = false
                 logger.notice("All settings have been reset")
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will reset all settings to their default values and clear all cached data. This action cannot be undone.")
+            Text("This will reset all settings to their default values, clear all cached data, and sign you out. This action cannot be undone.")
         }
     }
     


### PR DESCRIPTION
#### Description:
- if you are an admin and sign out, you should no longer see admin stats
- if you click reset all app data, we should reset ALL app data (sign out, favorites, etc.)

#### Attachment(s):

https://github.com/user-attachments/assets/22de30fc-a1de-4a14-bbd5-962a35088f84


#### Note(s):
